### PR TITLE
Feature/aurora scheduler docker tagging

### DIFF
--- a/pkg/tagger/collectors/docker_extract_test.go
+++ b/pkg/tagger/collectors/docker_extract_test.go
@@ -102,6 +102,43 @@ func TestDockerRecordsFromInspect(t *testing.T) {
 			expectedHigh: []string{"mesos_task:system_dd-agent.dcc75b42-4b87-11e7-9a62-70b3d5800001"},
 		},
 		{
+			testName: "extractAuroraSchedulerAuroraJob",
+			co: &types.ContainerJSON{
+				Config: &container.Config{
+					Env: []string{
+						"MESOS_EXECUTOR_ID=thermos-test-role-devel-ddagent-0-f5a5ba97-115e-4119-a677-224aca32bcb7",
+					},
+					Labels: map[string]string{},
+				},
+			},
+			toRecordEnvAsTags:    map[string]string{},
+			toRecordLabelsAsTags: map[string]string{},
+			expectedLow:          []string{},
+			expectedHigh: []string{
+				"aurora.docker.executor:thermos",
+				"aurora.docker.role:test-role",
+				"aurora.docker.stage:devel",
+				"aurora.docker.job:ddagent",
+				"aurora.docker.instance:0",
+				"aurora.docker.id:f5a5ba97-115e-4119-a677-224aca32bcb7",
+			},
+		},
+		{
+			testName: "extractAuroraSchedulerNonAuroraJob",
+			co: &types.ContainerJSON{
+				Config: &container.Config{
+					Env: []string{
+						"MESOS_EXECUTOR_ID=system_dd-agent.dcc75b42-4b87-11e7-9a62-70b3d5800001",
+					},
+					Labels: map[string]string{},
+				},
+			},
+			toRecordEnvAsTags:    map[string]string{},
+			toRecordLabelsAsTags: map[string]string{},
+			expectedLow:          []string{},
+			expectedHigh: 		  []string{},
+		},
+		{
 			testName: "NoValue",
 			co: &types.ContainerJSON{
 				Config: &container.Config{

--- a/pkg/tagger/utils/regex.go
+++ b/pkg/tagger/utils/regex.go
@@ -1,0 +1,19 @@
+package utils
+
+import (
+	"regexp"
+)
+
+func RegexGroupsToMap(exp, str string) (groupsMap map[string]string) {
+
+	var compRegEx = regexp.MustCompile(exp)
+	match := compRegEx.FindStringSubmatch(str)
+
+	groupsMap = make(map[string]string)
+	for i, name := range compRegEx.SubexpNames() {
+		if i > 0 && i <= len(match) {
+			groupsMap[name] = match[i]
+		}
+	}
+	return groupsMap
+}


### PR DESCRIPTION
### What does this PR do?
Parses aurora tags (executor, role, stage, job, id) from MESOS_EXECUTOR_ID environment variable inside docker container.  This is required because the mesos agent container names are not useful when attempting to monitor a specific container.

### Motivation

Utilization of Apache Aurora Scheduler with Mesos in our stack with need to quickly locate docker container based on Aurora executor, role, stage, job, or id.

### Additional Notes

Added tests to simulate the successful parsing of the `MESOS_EXECUTOR_ID` env var with aurora tags as well as the unsuccessful parsing of the `MESOS_EXECUTOR_ID` env var with no aurora tags.
