### PR TITLE
feature/add_aurora_docker_task_tag

### DIFF
--- a/pkg/tagger/collectors/docker_extract.go
+++ b/pkg/tagger/collectors/docker_extract.go
@@ -139,8 +139,11 @@ func dockerExtractAuroraTagsFromExecId(execId string) (auroraTags map[string]str
 
 	auroraTags = utils.RegexGroupsToMap(exp, execId)
 
+	// Add full MESOS_EXECUTOR_ID value as Aurora task tag
+	auroraTags["task"] = execId
+
 	// Confirm complete regex match for all keys before setting tags (empty map if fail)
-	var auroraKeys = [6]string{"executor", "role", "stage", "job", "instance", "id"}
+	var auroraKeys = [7]string{"executor", "role", "stage", "job", "instance", "id", "task"}
 
 	for _, key := range auroraKeys {
 		if _, present := auroraTags[string(key)]; !present {

--- a/pkg/tagger/collectors/docker_extract_test.go
+++ b/pkg/tagger/collectors/docker_extract_test.go
@@ -121,6 +121,7 @@ func TestDockerRecordsFromInspect(t *testing.T) {
 				"aurora.docker.job:ddagent",
 				"aurora.docker.instance:0",
 				"aurora.docker.id:f5a5ba97-115e-4119-a677-224aca32bcb7",
+				"aurora.docker.task:thermos-test-role-devel-ddagent-0-f5a5ba97-115e-4119-a677-224aca32bcb7",
 			},
 		},
 		{


### PR DESCRIPTION
### What does this PR do?

Add aurora.docker.task tag with full value of MESOS_EXECUTOR_ID environment variable to reflect full aurora task identifier for job started by Apache Aurora Scheduler.

### Motivation

The MESOS_EXECUTOR_ID environment variable value is equal to the Aurora Task name associated with the job.  This information is required as a tag for monitoring, dashboards, and reports.

### Additional Notes

None
