### PR TITLE
Feature/tags_to_low_cardinality

### DIFF
--- a/pkg/tagger/collectors/docker_extract.go
+++ b/pkg/tagger/collectors/docker_extract.go
@@ -106,7 +106,7 @@ func dockerExtractEnvironmentVariables(tags *utils.TagList, containerEnvVariable
 		// Apache Aurora Scheduler
 		case "MESOS_EXECUTOR_ID":
 			for k, v := range dockerExtractAuroraTagsFromExecId(envValue) {
-				tags.AddHigh(fmt.Sprintf("aurora.docker.%s", k), v)
+				tags.AddLow(fmt.Sprintf("aurora.docker.%s", k), v)
 			}
 
 		// Nomad

--- a/pkg/tagger/collectors/docker_extract_test.go
+++ b/pkg/tagger/collectors/docker_extract_test.go
@@ -113,8 +113,7 @@ func TestDockerRecordsFromInspect(t *testing.T) {
 			},
 			toRecordEnvAsTags:    map[string]string{},
 			toRecordLabelsAsTags: map[string]string{},
-			expectedLow:          []string{},
-			expectedHigh: []string{
+			expectedLow: []string{
 				"aurora.docker.executor:thermos",
 				"aurora.docker.role:test-role",
 				"aurora.docker.stage:devel",
@@ -123,6 +122,7 @@ func TestDockerRecordsFromInspect(t *testing.T) {
 				"aurora.docker.id:f5a5ba97-115e-4119-a677-224aca32bcb7",
 				"aurora.docker.task:thermos-test-role-devel-ddagent-0-f5a5ba97-115e-4119-a677-224aca32bcb7",
 			},
+			expectedHigh: []string{},
 		},
 		{
 			testName: "extractAuroraSchedulerNonAuroraJob",
@@ -137,7 +137,7 @@ func TestDockerRecordsFromInspect(t *testing.T) {
 			toRecordEnvAsTags:    map[string]string{},
 			toRecordLabelsAsTags: map[string]string{},
 			expectedLow:          []string{},
-			expectedHigh: 		  []string{},
+			expectedHigh:         []string{},
 		},
 		{
 			testName: "NoValue",


### PR DESCRIPTION
### What does this PR do?

Set Aurora tags to low cardinality so that they are applied to all docker metrics.

### Motivation

Need to be able to drill down to specific Aurora tag with any docker metric.

### Additional Notes

n/a
