### PR TITLE
Add go build tags

### DIFF
--- a/pkg/tagger/collectors/docker_extract.go
+++ b/pkg/tagger/collectors/docker_extract.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
+//go:build docker
 // +build docker
 
 package collectors

--- a/pkg/tagger/collectors/docker_extract_test.go
+++ b/pkg/tagger/collectors/docker_extract_test.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2018 Datadog, Inc.
 
+//go:build docker
 // +build docker
 
 package collectors


### PR DESCRIPTION
## Summary
- add modern go build tags for docker collectors

## Testing
- `go test ./pkg/tagger/collectors -run TestDockerRecordsFromInspect -tags docker` *(fails: cannot find main module)*

------
https://chatgpt.com/codex/tasks/task_b_687ffdf442d8832ca1dcec88c2343350